### PR TITLE
Convert hash values to string for digest, and allow different digest methods to be used

### DIFF
--- a/app/controllers/sso_controller.rb
+++ b/app/controllers/sso_controller.rb
@@ -25,6 +25,8 @@ class SsoController < ApplicationController
     # 4. Generate the jsConnect string.
     secure = true # this should be true unless you are testing.
     json = JsConnect.getJsConnectString(user, self.params, client_id, secret, secure)
+    # To use a different digest such as SHA1 
+    # json = JsConnect.getJsConnectString(user, self.params, client_id, secret, secure, Digest::SHA1)
     
     render :text => json
   end

--- a/lib/js_connect.rb
+++ b/lib/js_connect.rb
@@ -72,7 +72,7 @@ module JsConnect
       end
       
        value = data[key]
-       sig_str += CGI.escape(key) + "=" + CGI.escape(value)
+       sig_str += CGI.escape(key) + "=" + CGI.escape(value.to_s)
      end
      
      signature = Digest::MD5.hexdigest(sig_str + secret);

--- a/lib/js_connect.rb
+++ b/lib/js_connect.rb
@@ -9,7 +9,7 @@ module JsConnect
       return {"error" => code, "message" => message}
     end
     
-    def JsConnect.getJsConnectString(user, request = {}, client_id = "", secret = "", secure = true)
+    def JsConnect.getJsConnectString(user, request = {}, client_id = "", secret = "", secure = true, digest = Digest::MD5)
       error = nil
       
       timestamp = request["timestamp"].to_i
@@ -36,7 +36,7 @@ module JsConnect
           error = JsConnect.error('invalid_request', 'The timestamp is invalid.')
         else
           # Make sure the timestamp's signature checks out.
-          timestamp_sig = Digest::MD5.hexdigest(timestamp.to_s + secret)
+          timestamp_sig = digest.hexdigest(timestamp.to_s + secret)
           if timestamp_sig != request['signature']
             error = JsConnect.error('access_denied', 'Signature invalid.')
           end
@@ -47,7 +47,7 @@ module JsConnect
         result = error
       elsif user and !user.empty?
         result = user.clone
-        JsConnect.signJsConnect(result, client_id, secret, true)
+        JsConnect.signJsConnect(result, client_id, secret, true, digest)
       else
         result = {"name" => "", "photourl" => ""}
       end
@@ -60,7 +60,7 @@ module JsConnect
       end
     end
     
-   def JsConnect.signJsConnect(data, client_id, secret, set_data = false)
+   def JsConnect.signJsConnect(data, client_id, secret, set_data = false, digest = Digest::MD5)
      # Build the signature string. This is essentially a querystring representation of data, sorted by key
      keys = data.keys.sort { |a,b| a.downcase <=> b.downcase }
      
@@ -75,7 +75,7 @@ module JsConnect
        sig_str += CGI.escape(key) + "=" + CGI.escape(value.to_s)
      end
      
-     signature = Digest::MD5.hexdigest(sig_str + secret);
+     signature = digest.hexdigest(sig_str + secret);
      
      if set_data
        data["clientid"] = client_id

--- a/spec/js_connect_spec.rb
+++ b/spec/js_connect_spec.rb
@@ -1,0 +1,31 @@
+require_relative "../lib/js_connect.rb"
+require 'cgi'
+require 'digest/md5'
+
+describe JsConnect do
+
+  let(:client_id) { '12345' }
+  let(:secret) { 'thisisasecrethash' }
+  let(:data) do
+    {
+      'uniqueid' => '1',
+      'name' => 'John Doe',
+      'email' => 'john@doe.com',
+      'photourl' => 'http://johndoe.com/avatar.jpg'
+    }
+  end
+
+  describe "signJsConnect" do
+    it "returns a signature" do
+      signature = JsConnect.signJsConnect(data, client_id, secret)
+      signature.should eq('d4a550344e2557116a328c15eebcc997')
+    end
+
+    it "converts the data hash values to string for hexdigest" do
+      data['uniqueid'] = 1
+      signature = JsConnect.signJsConnect(data, client_id, secret)
+      signature.should eq('d4a550344e2557116a328c15eebcc997')
+    end
+  end
+
+end

--- a/spec/js_connect_spec.rb
+++ b/spec/js_connect_spec.rb
@@ -1,6 +1,15 @@
 require_relative "../lib/js_connect.rb"
 require 'cgi'
 require 'digest/md5'
+require 'json'
+
+class DummyJSON
+
+  def self.encode(result)
+    result
+  end
+
+end
 
 describe JsConnect do
 
@@ -16,7 +25,7 @@ describe JsConnect do
   end
 
   describe "signJsConnect" do
-    it "returns a signature" do
+    it "returns a signature based on MD5" do
       signature = JsConnect.signJsConnect(data, client_id, secret)
       signature.should eq('d4a550344e2557116a328c15eebcc997')
     end
@@ -25,6 +34,41 @@ describe JsConnect do
       data['uniqueid'] = 1
       signature = JsConnect.signJsConnect(data, client_id, secret)
       signature.should eq('d4a550344e2557116a328c15eebcc997')
+    end
+
+    context "when specifying SHA1 as digest" do
+      it "returns a signature with SHA1 as digest" do
+        signature = JsConnect.signJsConnect(data, client_id, secret, false, Digest::SHA1)
+        signature.should eq('d57a237e617f19454ac888047d386e5878d78fe7')
+      end
+    end    
+  end
+
+  describe "getJsConnectString" do
+    before(:each) do
+      stub_const("ActiveSupport::JSON", DummyJSON)
+    end
+
+    it "uses MD5 digest by default" do
+      timestamp = Time.now.to_i
+      signature = Digest::MD5.hexdigest(timestamp.to_s + secret)
+      request = { 'client_id' => '12345', 'timestamp' => timestamp.to_s, 'signature' => signature }
+
+      Digest::MD5.should_receive(:hexdigest).with(timestamp.to_s + secret).and_call_original
+      JsConnect.should_receive(:signJsConnect).with(data, client_id, secret, true, Digest::MD5)
+      JsConnect.getJsConnectString(data, request, client_id, secret)
+    end
+
+    context "when specifying a SHA1 as digest" do
+      it "uses SHA1 digest instead of the default" do
+        timestamp = Time.now.to_i
+        signature = Digest::SHA1.hexdigest(timestamp.to_s + secret)
+        request = { 'client_id' => '12345', 'timestamp' => timestamp.to_s, 'signature' => signature }
+
+        Digest::SHA1.should_receive(:hexdigest).with(timestamp.to_s + secret).and_call_original
+        JsConnect.should_receive(:signJsConnect).with(data, client_id, secret, true, Digest::SHA1)
+        JsConnect.getJsConnectString(data, request, client_id, secret, true, Digest::SHA1)
+      end
     end
   end
 


### PR DESCRIPTION
Sending a hash with an integer value caused CGI.escape to choke as it is expecting a string. I find by default that passing a hash with { 'uniqueid' => current_user.id } feels natural. So I've applied a fix for that.

On the Vanilla Forums site, it says that it is recommended to use SHA1 as digest, however MD5 was hardcoded, so I am applying a fix for that as well. So now MD5 is on by default (for backward compatibility), but allows any digest to be used. 

I've included some rspec test for the updates.

Thanks, Marcus