### PR TITLE
Send response as JavaScript in example controller

### DIFF
--- a/app/controllers/sso_controller.rb
+++ b/app/controllers/sso_controller.rb
@@ -26,7 +26,7 @@ class SsoController < ApplicationController
     secure = true # this should be true unless you are testing.
     json = JsConnect.getJsConnectString(user, self.params, client_id, secret, secure)
 
-    render :text => json
+    render :js => json
   end
 
 end


### PR DESCRIPTION
Getting this with Chrome on sign in:

> Refused to execute script from '(my URL)' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.

Sending the result as JS fixes it.